### PR TITLE
Add <a name=""> links to all the terms in the glossary.

### DIFF
--- a/homeworlds/site/glossary.html
+++ b/homeworlds/site/glossary.html
@@ -52,16 +52,16 @@ This affects the length and style of the game.
     <li> <a href="#starDemolition">Star demolition</a> against each of your opponent's two home stars.
 </ul>
 
-<li> <u>Abandonment</u><br>
+<li> <a name="abandonment"/><u>Abandonment</u><br>
     Removing the last ship from a system so that it <a href="#fade">fades</a>
     (its marker(s) return to the bank).
 
-<li> <u>Achilles color</u><br>
+<li> <a name="achillesColor"/><u>Achilles color</u><br>
     The color of the only system marker of your homeworld (after one star has been destroyed).
     Since your opponent can will by causing one catastrophe of that color at your home,
     that color is your "weak spot."
 
-<li> <u>Binary</u><br>
+<li> <a name="binary"/><u>Binary</u><br>
     "Binary" has two meanings in Homeworlds.
     <ul>
         <li> Homeworlds was originally conceived as a four-player game.
@@ -74,7 +74,7 @@ This affects the length and style of the game.
         <li> "Binary stars" are the two star markers in players' home systems at the start of the game.
     </ul>
 
-<li> <a name="bluebird"/><u>Blurbird mistakes</u><br>
+<li> <a name="bluebird"/><u>Bluebird mistakes</u><br>
     Allowing your entire home fleet to be destroyed in a single catastrophe.
     <ul>
     <li> <u>Sitting duck</u><br>
@@ -134,10 +134,10 @@ This affects the length and style of the game.
 <li> <a name="directAssault"/><u>Direct assault</u><br>
     Taking <a href="#control">control</a> of a system (especially a homeworld) by using red power to attack the enemy ships.
 
-<li> <u>Discovery</u><br>
+<li> <a name="discovery"/><u>Discovery</u><br>
     Moving a ship to a new system with a marker taken from the bank.
 
-<li> <u>Doomsday machine</u><br>
+<li> <a name="doomsdayMachine"/><u>Doomsday machine</u><br>
     A collection of nine ships arranged such that they can destroy
     the opponent's homeworld in two turns.
     The ships you need are
@@ -157,7 +157,7 @@ This affects the length and style of the game.
     to move each of the groups of three ships into your opponent's home
     and declaring the catastrophe.
 
-<li> <u>Factory</u><br>
+<li> <a name="factory"/><u>Factory</u><br>
     A large green ship and at least one other green ship
     when there are no greens left in the bank.
     The g3  may be sacrificed and rebuilt
@@ -167,25 +167,25 @@ This affects the length and style of the game.
     A catastrophe that destroys all of a player's ships in their own homeworld
     (see <a href="#bluebird">the Bluebird mistakes</a>).
 
-<li> <u>Frozen out</u><br>
+<li> <a name="frozenOut"/><u>Frozen out</u><br>
     The inability to (safely) get even a single ship of some color.
     If one player is frozen out of some color,
     their opponent has a "monopoly" on that color.
 
-<li> <u>Galactic overlord</u><br>
+<li> <a name="galacticOverlord"/><u>Galactic overlord</u><br>
     This was never an official game term,
     but in 2020, Andy Looney asked the Homeworlds Facebook group
     what they thought about referring to all Homeworlds players as "galactic overlords"
     (as a replacement for "<a href="#starshipCaptain">starship captain</a>").
     He decided not to include the term in the official rules.
 
-<li> <u>Green teleport</u><br>
+<li> <a name="greenTeleport"/><u>Green teleport</u><br>
     Sacrificing a green to rebuild it in another system.
 
-<li> <a name="happySystem"/><u>Happy system</u><br>
+<li> <a name="happySystem"/><a name="happySystem"/><u>Happy system</u><br>
     An <a href="#contest">uncontested</a> system with exactly one piece of each color (including system markers).
 
-<li> <u>Homeworld</u><br>
+<li> <a name="homeworld"/><u>Homeworld</u><br>
     A player-owned system for which the game is named.
     A player's homeworld may be called their home, home system, or homeworld system.
     Just as as the terms "<a href="#system">system</a>" and "<a href="#star">star</a>"
@@ -203,7 +203,7 @@ This affects the length and style of the game.
     The change in system connectivity that occurs
     when one marker is destroyed in a home system.
 
-<li> <u>Investment</u><br>
+<li> <a name="investment"/><u>Investment</u><br>
     Occupying a larger-marker system with a green ship
     with the intention of sacrificing the green piece
     and immediately building the large marker as a ship.
@@ -213,10 +213,10 @@ This affects the length and style of the game.
 <li> <a name="jrSrOfficers"/><u>Junior and senior officers</u><br>
     Relatively inexperienced and experienced Homeworlds players, respectively.
 
-<li> <u>Keep-away</u><br>
+<li> <a name="keepaway"/><u>Keep-away</u><br>
     Discovering a star rather than letting your opponent build the marker piece as a ship.
 
-<li> <u>Overpopulation</u><br>
+<li> <a name="overpopulation"/><u>Overpopulation</u><br>
     The presence of four (or more) pieces of the same color in a system
     (including ships and system markers).
     If an overpopulation is present anywhere in the game,
@@ -226,7 +226,7 @@ This affects the length and style of the game.
 <li> <a name="planetaryDefense"/><u>Planetary defense system</u><br>
     A red star in a home system.
 
-<li> <u>Primary directive</u><br>
+<li> <a name="primaryDirective"/><u>Primary directive</u><br>
     Defend the homeworld with these principles:
     <ul>
         <li> Keep a large ship in your homeworld.
@@ -235,10 +235,10 @@ This affects the length and style of the game.
         <li> Once one star is destroyed, monopolize the other color.
     </ul>
 
-<li> <u>Quick start</u><br>
+<li> <a name="quickStart"/><u>Quick start</u><br>
     A homeworld configuration including a yellow star.
 
-<li> <u>Red alert</u><br>
+<li> <a name="redAlert"/><u>Red alert</u><br>
     A warning that a player might give to their opponent
     who is one move away from elimination
     (equivalent to "check" in chess).
@@ -250,7 +250,7 @@ This affects the length and style of the game.
 <li> <a name="starDemolition"/><u>Star demolition</u><br>
     Destroying a star with a catastrphe.
 
-<li> <u>Star-towing</u><br>
+<li> <a name="starTowing"/><u>Star-towing</u><br>
     Moving the physical play pieces (especially system markers) to clarify their relationships.
     Players often arrange the star map with the convention that
     systems controlled by a played placed on the same side of the play area.
@@ -262,7 +262,7 @@ This affects the length and style of the game.
     Historically, all Homeworlds players were called starship captains
     (see also <a href="#galacticOverlord">galactic overlord</a>).
 
-<li> <u>Squonking</u><br>
+<li> <a name="squonking"/><u>Squonking</u><br>
     Sacrificing a ship to prevent its capture.<br>
     Andy also uses the term for trading a ship to block larger builds,
     as in <a href="https://www.youtube.com/watch?v=qGbIxb9lFds&t=1450s">this Homeworlds Theater</a>.
@@ -271,7 +271,7 @@ This affects the length and style of the game.
     A "space" marked with a <a href="#star">star</a> which may be occupied by ships.
     The word "system" sometimes refers directly to the star itself.
 
-<li> <u>Terraforming</u><br>
+<li> <a name="terraforming"/><u>Terraforming</u><br>
     Sacrificing a yellow ship and discovering the piece as a star in the same move.
 </ul>
 
@@ -334,10 +334,10 @@ Terms I use
         if it is connected to neither home.
     </ul>
 
-<li> <u>Andy's home</u><br>
+<li> <a name="andysHome"/><u>Andy's home</u><br>
     The homeworld with b2 and r1 stars and a g3 ship (<a href="http://www.wunderland.com/WTS/Andy/Games/ILoveHomeworlds.html#Opening">Andy's standard start</a>).
 
-<li> <u>Big no-no</u><br>
+<li> <a name="bigNoNo"/><u>Big no-no</u><br>
     Failing to keep a large ship in your homeworld.
 
 <li> <a name="concentration"/><u>Concentration</u><br>
@@ -357,7 +357,7 @@ Terms I use
     or to get an additional large ship
     without giving your opponent the chance to get a large ship.
 
-<li> <u>Doomsweek machine</u><br>
+<li> <a name="doomsweekMachine"/><u>Doomsweek machine</u><br>
     Like a Doomsday machine but slow-acting, <a href="tactics.html#doomsweek">explained here</a>.
 
 <li> <a name="fade"/><u>Fade</u><br>
@@ -365,7 +365,7 @@ Terms I use
     This is the consequence of the system being abandoned.
 
 
-<li> <u>Gilligan</u> (until I think of a better name)<br>
+<li> <a name="gilligan"/><u>Gilligan</u> (until I think of a better name)<br>
     A ship that is "stuck" in a system because there is no yellow or blue there.
     If there were yellow, the ship could leave.
     If there were blue, the ship could turn yellow and leave.
@@ -380,14 +380,14 @@ Terms I use
     Also the threat of sacrificing a red Gilligan can be a useful
     <a href="strategyGuide.html#deterrent">deterrent</a>.
 
-<li> <u>Instafreeze</u><br>
+<li> <a name="instafreeze"/><u>Instafreeze</u><br>
    The fastest possible economic freeze, <a href="tactics.html#instafreeze">explained here</a>.
 
-<li> <u>Local economy</u><br>
+<li> <a name="localEconomy"/><u>Local economy</u><br>
     The collection of colors at a particular system.
     For example, if you move/trade away your last red ship in a system, you have lost the local red economy.
 
-<li> <u>Material</u><br>
+<li> <a name="material"/><u>Material</u><br>
     The amount of ship power a player has.
     A player has a material advantage if they have more ships or larger ships.
     Very roughly, material can be measured
@@ -401,10 +401,10 @@ Terms I use
         <li> each additional large ship = 7
         </ul>
 
-<li> <u>Milking the cow</u><br>
+<li> <a name="milking"/><u>Milking the cow</u><br>
     Repeatedly building and trading a large ship of a color that you have monopolized.
 
-<li> <u>Red ram</u><br>
+<li> <a name="redRam"/><u>Red ram</u><br>
     A red ship that is sacrificed in order to capture a red ship in the same system
     when the opponent is attempting a red catastrophe.
     The attack could have been performed without the sacrifice,
@@ -415,7 +415,7 @@ Terms I use
     <a href="tactics.html#noSlowRedCat">this section</a>
     on preventing slow red catastrophes.
 
-<li> <u>Soft freeze</u><br>
+<li> <a name="softFreeze"/><u>Soft freeze</u><br>
     When a player has one ship of a color, but they can't safely build another ship of that color.
     This happens often when a player's only ship of some color is the large at their home system
     and they also have a home star of that color.


### PR DESCRIPTION
I'd like to link to `#doomsdayMachine` from a blog post ([here](https://quuxplusone.github.io/blog/2020/05/29/homeworlds-mini-doomsday-machine/)), and to do that I need an anchor tag on your page. Consider adding one... or all of these? :)

Also fix typo /Blurbird/Bluebird/ in one place.