### PR TITLE
Fix link to Demolition Fleet glossary entry

### DIFF
--- a/homeworlds/site/guide/middle.html
+++ b/homeworlds/site/guide/middle.html
@@ -62,7 +62,7 @@ Contrariwise, it's good if your opponent has one of these problems.
     <li> The ship(s) in my home system are all the same color
     (the <a href='../glossary.html#bluebird'/>Bluebird</a> mistake).
     <li> My only large ship in my home system is the same color as one (or more!) ships or markers in my home
-    (my opponent might get a <a href='glossary.html#demolition_fleet'>Demolition Fleet</a>).
+    (my opponent might get a <a href='../glossary.html#demolition_fleet'>Demolition Fleet</a>).
 </ol>
 </p>
 


### PR DESCRIPTION
I just added the "../" to fix a 404 error